### PR TITLE
Properly move files across disks

### DIFF
--- a/src/Core/fileentry.cpp
+++ b/src/Core/fileentry.cpp
@@ -97,7 +97,7 @@ void ShadyCore::Package::saveDir(const std::filesystem::path& directory) {
 		try {
 			std::filesystem::rename(tempFile, target / targetType.appendExtValue(filename));
 		} catch (std::filesystem::__cxx11::filesystem_error &) {
-			std::filesystem::copy(tempFile, target);
+			std::filesystem::copy(tempFile, target / targetType.appendExtValue(filename));
 			std::filesystem::remove(tempFile);
 		}
 	}

--- a/src/Core/fileentry.cpp
+++ b/src/Core/fileentry.cpp
@@ -94,15 +94,14 @@ void ShadyCore::Package::saveDir(const std::filesystem::path& directory) {
 		output.close();
 
 		std::wstring filename = sjis2ws(i->first.name);
-		try {
-			std::filesystem::rename(tempFile, target / targetType.appendExtValue(filename));
-		} catch (std::filesystem::__cxx11::filesystem_error &) {
-			try {
-				std::filesystem::remove(target / targetType.appendExtValue(filename));
-			} catch (std::filesystem::__cxx11::filesystem_error &) {}
-			std::filesystem::copy(tempFile, target / targetType.appendExtValue(filename));
-			std::filesystem::remove(tempFile);
-		}
+		std::error_code err;
+
+		std::filesystem::rename(tempFile, target / targetType.appendExtValue(filename), err);
+		if (!err)
+			continue;
+		std::filesystem::remove(target / targetType.appendExtValue(filename), err);
+		std::filesystem::copy(tempFile, target / targetType.appendExtValue(filename));
+		std::filesystem::remove(tempFile);
 	}
 }
 

--- a/src/Core/fileentry.cpp
+++ b/src/Core/fileentry.cpp
@@ -94,7 +94,12 @@ void ShadyCore::Package::saveDir(const std::filesystem::path& directory) {
 		output.close();
 
 		std::wstring filename = sjis2ws(i->first.name);
-		std::filesystem::rename(tempFile, target / targetType.appendExtValue(filename));
+		try {
+			std::filesystem::rename(tempFile, target / targetType.appendExtValue(filename));
+		} catch (std::filesystem::__cxx11::filesystem_error &) {
+			std::filesystem::copy(tempFile, target);
+			std::filesystem::remove(tempFile);
+		}
 	}
 }
 

--- a/src/Core/fileentry.cpp
+++ b/src/Core/fileentry.cpp
@@ -97,6 +97,9 @@ void ShadyCore::Package::saveDir(const std::filesystem::path& directory) {
 		try {
 			std::filesystem::rename(tempFile, target / targetType.appendExtValue(filename));
 		} catch (std::filesystem::__cxx11::filesystem_error &) {
+			try {
+				std::filesystem::remove(target / targetType.appendExtValue(filename));
+			} catch (std::filesystem::__cxx11::filesystem_error &) {}
 			std::filesystem::copy(tempFile, target / targetType.appendExtValue(filename));
 			std::filesystem::remove(tempFile);
 		}

--- a/src/Core/package.cpp
+++ b/src/Core/package.cpp
@@ -125,15 +125,14 @@ void ShadyCore::Package::save(const std::filesystem::path& filename, Mode mode) 
 	std::filesystem::path tempFile = ShadyUtil::TempFile();
 	if (mode == DATA_MODE) saveData(tempFile);
 	if (mode == ZIP_MODE) saveZip(tempFile);
-	try {
-		std::filesystem::rename(tempFile, target);
-	} catch (std::filesystem::__cxx11::filesystem_error &) {
-		try {
-			std::filesystem::remove(target);
-		} catch (std::filesystem::__cxx11::filesystem_error &) {}
-		std::filesystem::copy(tempFile, target);
-		std::filesystem::remove(tempFile);
-	}
+
+	std::error_code err;
+	std::filesystem::rename(tempFile, target, err);
+	if (!err)
+		return;
+	std::filesystem::remove(target, err);
+	std::filesystem::copy(tempFile, target);
+	std::filesystem::remove(tempFile);
 }
 
 ShadyCore::FileType ShadyCore::Package::iterator::fileType() const {

--- a/src/Core/package.cpp
+++ b/src/Core/package.cpp
@@ -128,6 +128,9 @@ void ShadyCore::Package::save(const std::filesystem::path& filename, Mode mode) 
 	try {
 		std::filesystem::rename(tempFile, target);
 	} catch (std::filesystem::__cxx11::filesystem_error &) {
+		try {
+			std::filesystem::remove(target);
+		} catch (std::filesystem::__cxx11::filesystem_error &) {}
 		std::filesystem::copy(tempFile, target);
 		std::filesystem::remove(tempFile);
 	}

--- a/src/Core/package.cpp
+++ b/src/Core/package.cpp
@@ -125,7 +125,12 @@ void ShadyCore::Package::save(const std::filesystem::path& filename, Mode mode) 
 	std::filesystem::path tempFile = ShadyUtil::TempFile();
 	if (mode == DATA_MODE) saveData(tempFile);
 	if (mode == ZIP_MODE) saveZip(tempFile);
-	std::filesystem::rename(tempFile, target);
+	try {
+		std::filesystem::rename(tempFile, target);
+	} catch (std::filesystem::__cxx11::filesystem_error &) {
+		std::filesystem::copy(tempFile, target);
+		std::filesystem::remove(tempFile);
+	}
 }
 
 ShadyCore::FileType ShadyCore::Package::iterator::fileType() const {


### PR DESCRIPTION
On Linux, `tempnam` will return a path to /tmp, which on most distros, points to a tmpfs disk. Because of that, `std::filesystem::rename` fails and throws an exception, that crashes the process:
```
terminate called after throwing an instance of 'std::filesystem::__cxx11::filesystem_error'
  what():  filesystem error: cannot rename: Invalid cross-device link [/tmp/shady7MSc9s] [/home/pinky/projects/SokuProjects/CharacterEngine/src/tewi/tewi.dat]
```
If rename fails, then the temp file is copied, then removed. That ensures that the file is moved no matter what.