### PR TITLE
Pack command properly generates .dat folder structure

### DIFF
--- a/src/Cli/CMakeLists.txt
+++ b/src/Cli/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SRC_CLI
 	merge-palette.cpp
 	pack.cpp
 	scale.cpp
+	list.cpp
 )
 
 if(WIN32)
@@ -19,5 +20,9 @@ endif()
 
 source_group("Source Files" FILES ${SRC_CLI})
 add_executable(shady-cli ${SRC_CLI})
+if (WIN32)
 target_link_libraries(shady-cli -static shady-core cxxopts)
+else()
+target_link_libraries(shady-cli  shady-core cxxopts)
+endif()
 install(TARGETS shady-cli RUNTIME DESTINATION bin)

--- a/src/Cli/command.cpp
+++ b/src/Cli/command.cpp
@@ -24,6 +24,7 @@ void ShadyCli::Command::printHelp(const char* bin, Command* command) {
             "  %s <command> [COMMAND_OPTIONS]\n\n"
             "List of commands:\n"
             "  help     Prints help for commands.\n"
+	    "  list     List files inside package files.\n"
             "  convert  Converts game files into their encrypted/decrypted\n"
             "           counterpart.\n"
             "  merge    Merge many kind of files.\n"

--- a/src/Cli/command.cpp
+++ b/src/Cli/command.cpp
@@ -9,7 +9,10 @@ static inline ShadyCli::Command* getCommand(const char* arg) {
         return new ShadyCli::MergeCommand;
     } else if (strcmp(arg, "scale") == 0) {
         return new ShadyCli::ScaleCommand;
-    } return 0;
+    } else if (strcmp(arg, "list") == 0) {
+        return new ShadyCli::ListCommand;
+    }
+    return nullptr;
 }
 
 void ShadyCli::Command::printHelp(const char* bin, Command* command) {

--- a/src/Cli/command.hpp
+++ b/src/Cli/command.hpp
@@ -52,4 +52,11 @@ namespace ShadyCli {
         void buildOptions() override;
         bool run(const cxxopts::ParseResult&) override;
     };
+
+    class ListCommand : public Command {
+    public:
+        inline ListCommand() : Command("list", "List files in a package file.") {}
+        void buildOptions() override;
+        bool run(const cxxopts::ParseResult&) override;
+    };
 }

--- a/src/Cli/list.cpp
+++ b/src/Cli/list.cpp
@@ -1,0 +1,81 @@
+//
+// Created by PinkySmile on 05/10/24.
+//
+
+#include "command.hpp"
+#include "../Core/package.hpp"
+
+void ShadyCli::ListCommand::buildOptions() {
+	options.add_options()
+		("s,sort", "How to sort the output: `unsorted`, `type` or `path`.", cxxopts::value<std::string>()->default_value("unsorted"))
+		("files", "Source directories or data packages", cxxopts::value<std::vector<std::string> >())
+		;
+
+	options.parse_positional("files");
+	options.positional_help("<files>...");
+}
+
+std::string typeToString(ShadyCore::FileType type)
+{
+	switch (type.type) {
+	case ShadyCore::FileType::TYPE_TEXT:
+		return "[TEXT]   ";
+	case ShadyCore::FileType::TYPE_TABLE:
+		return "[TABLE]  ";
+	case ShadyCore::FileType::TYPE_LABEL:
+		return "[LABEL]  ";
+	case ShadyCore::FileType::TYPE_IMAGE:
+		return "[IMAGE]  ";
+	case ShadyCore::FileType::TYPE_PALETTE:
+		return "[PALETTE]";
+	case ShadyCore::FileType::TYPE_SFX:
+		return "[SFX]    ";
+	case ShadyCore::FileType::TYPE_BGM:
+		return "[BGM]    ";
+	case ShadyCore::FileType::TYPE_SCHEMA:
+		return "[SCHEMA] ";
+	case ShadyCore::FileType::TYPE_TEXTURE:
+		return "[TEXTURE]";
+	default:
+		return "[UNKNOWN]";
+	}
+}
+
+bool ShadyCli::ListCommand::run(const cxxopts::ParseResult& options) {
+	ShadyCore::PackageEx package;
+	std::string sort = options["sort"].as<std::string>();
+	auto &files = options["files"].as<std::vector<std::string>>();
+
+	size_t i = files.size();
+
+	while (i--) {
+		std::filesystem::path path(files[i]);
+
+		if (std::filesystem::exists(path)) {
+			package.merge(path);
+		}
+	}
+
+	std::vector<std::pair<std::string, std::string>> names;
+
+	names.reserve(package.size());
+	for (auto &files : package)
+		names.emplace_back(typeToString(files.first.fileType), files.first.actualName);
+
+	if (sort == "type") {
+		std::sort(names.begin(), names.end(), [](auto &a, auto &b) -> bool {
+			return a.first < b.first;
+		});
+	} else if (sort == "path") {
+		std::sort(names.begin(), names.end(), [](auto &a, auto &b) -> bool {
+			return a.second < b.second;
+		});
+	} else if (sort != "unsorted") {
+		std::cout << "Invalid sort." << std::endl;
+		return false;
+	}
+	for (auto &name : names)
+		std::cout << name.first << ": " << name.second << std::endl;
+	package.clear();
+	return true;
+}

--- a/src/Cli/pack.cpp
+++ b/src/Cli/pack.cpp
@@ -12,6 +12,7 @@ void ShadyCli::PackCommand::buildOptions() {
     options.add_options()
         ("o,output", "Target output file or directory.", cxxopts::value<std::string>())
         ("m,mode", "Output type to save: `data`, `dir` or `zip`. Saving to a directory will extract all files.", cxxopts::value<std::string>()->default_value("dir"))
+        ("r,recreate-structure", "When saving in `dir` mode, recreate the folder structure, instead of generating files with the folders in the name separated with a `_`.")
         ("files", "Source directories or data packages", cxxopts::value<std::vector<std::string> >())
         ;
 
@@ -22,6 +23,7 @@ void ShadyCli::PackCommand::buildOptions() {
 bool ShadyCli::PackCommand::run(const cxxopts::ParseResult& options) {
     ShadyCore::PackageEx package;
     ShadyCore::Package::Mode mode = getMode(options["mode"].as<std::string>());
+    bool structure = options["recreate-structure"].as<bool>();
     std::string output = options["output"].as<std::string>();
     auto& files = options["files"].as<std::vector<std::string> >();
 
@@ -34,6 +36,9 @@ bool ShadyCli::PackCommand::run(const cxxopts::ParseResult& options) {
         printf("Unknown mode \"%s\".\n", options["mode"].as<std::string>().c_str());
         return false;
     }
+
+    if (mode == ShadyCore::Package::DIR_MODE && structure)
+	    mode = ShadyCore::Package::FULL_DIR_MODE;
 
     size_t i = files.size();
     while (i--) {

--- a/src/Core/fileentry.cpp
+++ b/src/Core/fileentry.cpp
@@ -74,7 +74,7 @@ ShadyCore::FileType ShadyCore::GetFilePackageDefaultType(const FT& inputType, Sh
 	return outputTypes[inputType.type];
 }
 
-void ShadyCore::Package::saveDir(const std::filesystem::path& directory) {
+void ShadyCore::Package::saveDir(const std::filesystem::path& directory, bool recreateStructure) {
 	std::shared_lock lock(*this);
 	if (!std::filesystem::exists(directory)) std::filesystem::create_directories(directory);
 	else if (!std::filesystem::is_directory(directory)) return;
@@ -93,8 +93,20 @@ void ShadyCore::Package::saveDir(const std::filesystem::path& directory) {
 		i.close(input);
 		output.close();
 
-		std::wstring filename = sjis2ws(i->first.name);
-		std::filesystem::rename(tempFile, target / targetType.appendExtValue(filename));
+		// Use auto because on Windows sjis2ws returns a std::wstring and on Unix it returns a std::string
+		auto filename = recreateStructure ? sjis2ws(i->first.actualName) : sjis2ws(i->first.name);
+		std::filesystem::path final = target / targetType.appendExtValue(filename);
+
+		std::filesystem::create_directories(final.parent_path());
+		try {
+			std::filesystem::rename(tempFile, final);
+		} catch (std::filesystem::__cxx11::filesystem_error &) {
+			try {
+				std::filesystem::remove(final);
+			} catch (std::filesystem::__cxx11::filesystem_error &) {}
+			std::filesystem::copy(tempFile, final);
+			std::filesystem::remove(tempFile);
+		}
 	}
 }
 

--- a/src/Core/fileentry.cpp
+++ b/src/Core/fileentry.cpp
@@ -74,6 +74,15 @@ ShadyCore::FileType ShadyCore::GetFilePackageDefaultType(const FT& inputType, Sh
 	return outputTypes[inputType.type];
 }
 
+static inline std::string_view removeExt(const std::string_view &s)
+{
+	size_t pos = s.find_last_of('.');
+
+	if (pos == std::string_view::npos)
+		return s;
+	return s.substr(0, pos);
+}
+
 void ShadyCore::Package::saveDir(const std::filesystem::path& directory, bool recreateStructure) {
 	std::shared_lock lock(*this);
 	if (!std::filesystem::exists(directory)) std::filesystem::create_directories(directory);
@@ -94,7 +103,7 @@ void ShadyCore::Package::saveDir(const std::filesystem::path& directory, bool re
 		output.close();
 
 		// Use auto because on Windows sjis2ws returns a std::wstring and on Unix it returns a std::string
-		auto filename = recreateStructure ? sjis2ws(i->first.actualName) : sjis2ws(i->first.name);
+		auto filename = recreateStructure ? sjis2ws(removeExt(i->first.actualName)) : sjis2ws(i->first.name);
 		std::filesystem::path final = target / targetType.appendExtValue(filename);
 
 		std::filesystem::create_directories(final.parent_path());

--- a/src/Core/package.cpp
+++ b/src/Core/package.cpp
@@ -26,10 +26,10 @@ static inline std::string_view createNormalizedName(const std::string_view& str)
 }
 
 ShadyCore::Package::Key::Key(const std::string_view& str)
-	: name(createNormalizedName(str)), fileType(FileType::get(FileType::getExtValue(name.data() + name.size()))) {}
+	: actualName(str), name(createNormalizedName(str)), fileType(FileType::get(FileType::getExtValue(name.data() + name.size()))) {}
 
 ShadyCore::Package::Key::Key(const std::string_view& str, FileType::Type type)
-	: name(createNormalizedName(str)), fileType(type, FileType::FORMAT_UNKNOWN) {}
+	: actualName(str), name(createNormalizedName(str)), fileType(type, FileType::FORMAT_UNKNOWN) {}
 
 ShadyCore::Package::~Package() {
 	for (auto& entry : entries) {
@@ -116,7 +116,8 @@ ShadyCore::Package::iterator ShadyCore::Package::alias(const std::string_view& n
 }
 
 void ShadyCore::Package::save(const std::filesystem::path& filename, Mode mode) {
-	if (mode == DIR_MODE) return saveDir(filename);
+	if (mode == DIR_MODE) return saveDir(filename, false);
+	if (mode == FULL_DIR_MODE) return saveDir(filename, true);
 
 	std::filesystem::path target = std::filesystem::absolute(filename);
 	if (!std::filesystem::exists(target.parent_path()))
@@ -192,9 +193,9 @@ ShadyCore::PackageEx::~PackageEx() {
 
 ShadyCore::Package* ShadyCore::PackageEx::merge(Package* child) {
 	std::scoped_lock lock(*this, *child);
+
 	groups.push_back(child);
 	entries.merge(child->entries);
-
 	return child;
 }
 

--- a/src/Core/package.hpp
+++ b/src/Core/package.hpp
@@ -14,6 +14,7 @@ namespace ShadyCore {
 	protected:
 		class Key {
 		public:
+			const std::string actualName;
 			const std::string_view name;
 			const FileType fileType;
 
@@ -45,7 +46,7 @@ namespace ShadyCore {
 		void loadDir(const std::filesystem::path&);
 		void loadZip(const std::filesystem::path&);
 		void saveData(const std::filesystem::path&);
-		void saveDir(const std::filesystem::path&);
+		void saveDir(const std::filesystem::path&, bool recreateStructure);
 		void saveZip(const std::filesystem::path&);
 
 	public:
@@ -76,7 +77,7 @@ namespace ShadyCore {
 		//iterator rename(iterator i, const std::string_view& name);
 		iterator alias(const std::string_view& name, BasePackageEntry& entry);
 
-		enum Mode { DATA_MODE, ZIP_MODE, DIR_MODE };
+		enum Mode { DATA_MODE, ZIP_MODE, DIR_MODE, FULL_DIR_MODE };
 		void save(const std::filesystem::path&, Mode);
 		static void underlineToSlash(std::string&);
 	};

--- a/src/Core/zipentry.cpp
+++ b/src/Core/zipentry.cpp
@@ -291,9 +291,10 @@ void ShadyCore::Package::loadZip(const std::filesystem::path& path) {
 		zip_stat_t fileStat;
 		zip_stat_index(file, i, 0, &fileStat);
 
-		std::string_view name(fileStat.name);
+		std::string name(fileStat.name);
 		if (name.ends_with('/')) continue;
-		this->insert(fileStat.name, new ZipPackageEntry(this, fileStat.name, fileStat.size));
+		Package::underlineToSlash(name);
+		this->insert(name, new ZipPackageEntry(this, fileStat.name, fileStat.size));
 	}
 
 	zip_close(file);


### PR DESCRIPTION
I was trying to convert a folder of converted files into .dat using shady-cli, but it didn't work. I found it was because it sometimes replaced some / with _ even though the input folder structure was good.

<img src="https://github.com/user-attachments/assets/f9f9bd97-173a-4a55-9913-c545f98bf5e1" width="55%"/>
<img src="https://github.com/user-attachments/assets/9fbfd00a-edc9-4028-ad49-df17f3d1b144" width="40%"/>

*On the left, the .dat file viewed from the alpha preview gui version, and on the right the folder used to create it.*

I found it was pretty hard to find out because the cli helper doesn't provide a way to list files, and when extracting to a dir, or zip, no folder is created, rather, it replaces all the / in the paths with an _ and dumps everything to the output folder, like it would for a zip, so it's worthless to investigate that problem.

This pull request:
- Fixes a link error on Linux, by removing the `-static` flag conditionally
- Adds a `list` command, to list the files inside the dat, zip, and folders.
- Adds a `--recreate-structure` (or `-r`) to pack, to recreate the folder structure in dir mode, instead of replacing the / with an _
- Stores actual names (with _) inside the Package::Key class, for later use

Note: When importing a zip, the faulty `Package::underlineToSlash` is still used to remove the _ and replace them with a /, so the packing issue still persists when converting from a zip to dat. Also, since the actual file names are used, using an extracted zip folder will not work as before: It will store the files as-is in the dat, instead of removing the _.

Screenshots of the result:
![image](https://github.com/user-attachments/assets/be38c101-e4b2-4597-acae-b0f2c4960b27)
![image](https://github.com/user-attachments/assets/6addfe49-b7c0-4e4e-bf6d-aeb717131254)
![image](https://github.com/user-attachments/assets/2781c79a-5a1e-48c1-a8d6-1dd4220a3f88)
![image](https://github.com/user-attachments/assets/8d4803e7-4134-4c6f-af04-fc82c7ba7217)
![image](https://github.com/user-attachments/assets/05f5727e-3837-4259-b136-0aeb7ea6178e)
![image](https://github.com/user-attachments/assets/3767b219-23dc-4a11-b2e2-683a7cab383c)
![image](https://github.com/user-attachments/assets/74ed53de-6a67-44ee-b041-b7444a09af84)

![image](https://github.com/user-attachments/assets/26825480-84fa-4df6-838a-b1b60bf0db36)
